### PR TITLE
Critiacal fix for MutationAnnotator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-mutation-mapper",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Generic Mutation Mapper",
   "author": "cBioPortal",
   "license": "GNU Affero General Public License v3.0",

--- a/src/util/MutationAnnotator.ts
+++ b/src/util/MutationAnnotator.ts
@@ -135,15 +135,13 @@ export function getMutationFromSummary(mutation: Partial<Mutation>,
 
     // Entrez Gene id is critical for OncoKB annotation
     const entrezGeneId = parseInt(transcriptConsequenceSummary.entrezGeneId, 10);
-    // annotatedMutation.entrezGeneId = annotatedMutation.entrezGeneId || entrezGeneId;
 
     annotatedMutation.gene = {
+        ...annotatedMutation.gene,
         hugoGeneSymbol: (!overwrite && annotatedMutation.gene && annotatedMutation.gene.hugoGeneSymbol) ||
             transcriptConsequenceSummary.hugoGeneSymbol,
         entrezGeneId: (annotatedMutation.gene && annotatedMutation.gene.entrezGeneId) || entrezGeneId
     };
-
-    annotatedMutation.gene.entrezGeneId = annotatedMutation.gene.entrezGeneId || entrezGeneId;
 
     return annotatedMutation;
 }


### PR DESCRIPTION
This bug was causing the standalone cBioPortal mutation mapper tool to miss hotspot mutations completely.