### PR TITLE
Better formatting mutation rates

### DIFF
--- a/src/DefaultMutationRateSummary.tsx
+++ b/src/DefaultMutationRateSummary.tsx
@@ -1,6 +1,8 @@
 import {DefaultTooltip} from "cbioportal-frontend-commons";
 import * as React from "react";
 
+import {formatPercentValue} from "./util/FormatUtils";
+
 import styles from "./defaultMutationRateSummary.module.scss"
 
 export type MutationRate = {
@@ -11,6 +13,7 @@ export type MutationRate = {
 
 export type DefaultMutationRateSummaryProps = {
     rates: MutationRate[];
+    fractionDigits?: number;
 };
 
 export default class DefaultMutationRateSummary extends React.Component<DefaultMutationRateSummaryProps>
@@ -21,7 +24,7 @@ export default class DefaultMutationRateSummary extends React.Component<DefaultM
                 {this.props.rates.map(r => (
                     <div key={r.title} className={styles.mutationRateSummary}>
                         <span>{r.title}: </span>
-                        <span>{r.rate.toFixed(1)}%</span>
+                        <span>{formatPercentValue(r.rate, this.props.fractionDigits)}%</span>
                         {r.description &&
                             <DefaultTooltip
                                 placement="right"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -71,6 +71,7 @@ export {SequenceSpec} from "./model/SequenceSpec";
 export * from "./util/CancerHotspotsUtils";
 export * from "./util/DataFetcherUtils";
 export * from "./util/FilterUtils";
+export * from "./util/FormatUtils";
 export * from "./util/MutationAnnotator";
 export {
     MUTATION_TYPE_PRIORITY,

--- a/src/util/FormatUtils.ts
+++ b/src/util/FormatUtils.ts
@@ -1,0 +1,13 @@
+export function formatPercentValue(rate: number, fractionDigits: number = 1)
+{
+    const fixed = rate.toFixed(fractionDigits);
+
+    let displayValue = fixed;
+
+    // if the actual value is not zero but the display value is like 0.0, then show instead < 0.1
+    if (rate !== 0 && Number(fixed) === 0) {
+        displayValue = `< ${1 / Math.pow(10, fractionDigits)}`;
+    }
+
+    return displayValue;
+}


### PR DESCRIPTION
If the actual value is not zero but the display value is like `0.0`, then we are showing `< 0.1` instead