### PR TITLE
Improved data table component and styling

### DIFF
--- a/src/DataTable.tsx
+++ b/src/DataTable.tsx
@@ -17,7 +17,6 @@ import {DataStore} from "./model/DataStore";
 import {RemoteData} from "./model/RemoteData";
 import {TEXT_INPUT_FILTER_ID} from "./util/FilterUtils";
 import {getRemoteDataGroupStatus} from "./util/RemoteDataUtils";
-import './defaultDataTable.scss';
 
 export type DataTableColumn<T> = Column<T> & {
     name?: string;
@@ -45,6 +44,8 @@ export type DataTableProps<T> =
     showSearchBox?: boolean;
     onSearch?: (input: string, visibleSearchableColumns: DataTableColumn<T>[]) => void;
     searchDelay?: number;
+    searchPlaceholder?: string;
+    info?: JSX.Element;
     columnVisibility?: {[columnId: string]: boolean};
     columnSelectorProps?: ColumnSelectorProps;
 };
@@ -197,6 +198,8 @@ export default class DataTable<T> extends React.Component<DataTableProps<T>, {}>
                     onSearch={this.onSearch}
                     filterInputRef={this.filterInputRef}
                     searchDelay={this.props.searchDelay}
+                    searchPlaceHolder={this.props.searchPlaceholder}
+                    info={this.props.info}
                     showColumnVisibility={this.props.showColumnVisibility}
                     columnVisibility={this.columnVisibilityDef}
                     columnSelectorProps={this.props.columnSelectorProps}

--- a/src/DefaultMutationTable.tsx
+++ b/src/DefaultMutationTable.tsx
@@ -27,6 +27,8 @@ import {findNonTextInputFilters, TEXT_INPUT_FILTER_ID} from "./util/FilterUtils"
 import {getRemoteDataGroupStatus} from "./util/RemoteDataUtils";
 import DataTable, {DataTableColumn, DataTableProps} from "./DataTable";
 
+import './defaultMutationTable.scss';
+
 export type DefaultMutationTableProps = {
     hotspotData?: RemoteData<IHotspotIndex | undefined>;
     oncoKbData?: RemoteData<IOncoKbData | Error | undefined>;
@@ -312,6 +314,7 @@ export default class DefaultMutationTable extends React.Component<DefaultMutatio
                 columns={this.columns}
                 initialSortColumnData={this.initialSortColumnData}
                 onSearch={this.onSearch}
+                className="default-mutation-table"
             />
         );
     }

--- a/src/component/toolbar/DataTableToolbar.tsx
+++ b/src/component/toolbar/DataTableToolbar.tsx
@@ -15,6 +15,7 @@ type DataTableToolbarProps = {
     filterInputRef?: (input: HTMLInputElement) => void;
     searchDelay?: number;
     searchPlaceHolder?: string;
+    info?: JSX.Element;
 }
 
 @observer
@@ -26,6 +27,10 @@ export class DataTableToolbar extends React.Component<DataTableToolbarProps, {}>
         searchDelay: 400
     };
 
+    protected get searchBoxMargin() {
+        return this.props.showColumnVisibility ? 5 : "auto";
+    }
+
     public render()
     {
         return (
@@ -33,6 +38,7 @@ export class DataTableToolbar extends React.Component<DataTableToolbarProps, {}>
                 className="dataTableMainToolbar"
                 style={{paddingBottom: "0.4rem", display: "flex"}}
             >
+                {this.props.info}
                 {this.props.showColumnVisibility && (
                     <div
                         className="small"
@@ -48,7 +54,7 @@ export class DataTableToolbar extends React.Component<DataTableToolbarProps, {}>
                 {this.props.showSearchBox && (
                     <div
                         className="small"
-                        style={{width: 200, marginLeft: 5}}
+                        style={{width: 200, marginLeft: this.searchBoxMargin}}
                     >
                         <SearchBox
                             placeholder={this.props.searchPlaceHolder}

--- a/src/defaultMutationTable.scss
+++ b/src/defaultMutationTable.scss
@@ -1,4 +1,4 @@
-.default-data-table {
+.default-mutation-table {
     font-size: 0.8rem;
     min-width: 300px;
 


### PR DESCRIPTION
- Removed styling from `DataTable` component (using ReactTable defaults)
- Added the same styling to `DefaultMutationTable` instead
- Fixed a search box positioning issue
- Added support for info component into the `DataTableToolbar`