### PR TITLE
Provide default columns only if the columns is not defined in the property

### DIFF
--- a/src/MutationColumnHelper.tsx
+++ b/src/MutationColumnHelper.tsx
@@ -102,13 +102,13 @@ export const MUTATION_COLUMN_HEADERS = {
  * These default columns only include static props.
  * So, for some columns, like Annotation, no default accessor or Cell (render) properties included.
  */
-export const DEFAULT_MUTATION_COLUMNS = {
+export const MUTATION_COLUMNS_DEFINITION = {
     [MutationColumn.PROTEIN_CHANGE]: {
         id: MutationColumn.PROTEIN_CHANGE,
         name: MutationColumnName.PROTEIN_CHANGE,
         accessor: MutationColumn.PROTEIN_CHANGE,
         searchable: true,
-        Cell: (column: any) => <ProteinChange mutation={column.original} />,
+        Cell: (column: any) => <ProteinChange mutation={column.original}/>,
         Header: MUTATION_COLUMN_HEADERS[MutationColumn.PROTEIN_CHANGE],
         sortMethod: proteinChangeSortMethod
     },
@@ -123,7 +123,7 @@ export const DEFAULT_MUTATION_COLUMNS = {
         name: MutationColumnName.MUTATION_TYPE,
         accessor: MutationColumn.MUTATION_TYPE,
         searchable: true,
-        Cell: (column: any) => <MutationType mutation={column.original} />,
+        Cell: (column: any) => <MutationType mutation={column.original}/>,
         Header: MUTATION_COLUMN_HEADERS[MutationColumn.MUTATION_TYPE]
     },
     [MutationColumn.MUTATION_STATUS]: {
@@ -131,7 +131,7 @@ export const DEFAULT_MUTATION_COLUMNS = {
         name: MutationColumnName.MUTATION_STATUS,
         accessor: MutationColumn.MUTATION_STATUS,
         searchable: true,
-        Cell: (column: any) => <MutationStatus mutation={column.original} />,
+        Cell: (column: any) => <MutationStatus mutation={column.original}/>,
         Header: MUTATION_COLUMN_HEADERS[MutationColumn.MUTATION_STATUS]
     },
     [MutationColumn.CHROMOSOME]: {
@@ -187,6 +187,18 @@ export const DEFAULT_MUTATION_COLUMNS = {
         sortMethod: clinVarSortMethod
     }
 };
+
+export const DEFAULT_MUTATION_COLUMNS = [
+    MUTATION_COLUMNS_DEFINITION[MutationColumn.PROTEIN_CHANGE],
+    MUTATION_COLUMNS_DEFINITION[MutationColumn.MUTATION_TYPE],
+    MUTATION_COLUMNS_DEFINITION[MutationColumn.MUTATION_STATUS],
+    MUTATION_COLUMNS_DEFINITION[MutationColumn.CHROMOSOME],
+    MUTATION_COLUMNS_DEFINITION[MutationColumn.START_POSITION],
+    MUTATION_COLUMNS_DEFINITION[MutationColumn.END_POSITION],
+    MUTATION_COLUMNS_DEFINITION[MutationColumn.REFERENCE_ALLELE],
+    MUTATION_COLUMNS_DEFINITION[MutationColumn.VARIANT_ALLELE],
+    MUTATION_COLUMNS_DEFINITION[MutationColumn.CLINVAR]
+];
 
 export function mergeColumns(defaultColumns: Column<Partial<Mutation>>[],
                              customColumns: Column<Partial<Mutation>>[])

--- a/src/MutationMapper.tsx
+++ b/src/MutationMapper.tsx
@@ -22,6 +22,7 @@ import DefaultMutationTable from "./DefaultMutationTable";
 import GeneSummary from "./GeneSummary";
 import LollipopMutationPlot from "./LollipopMutationPlot";
 import {TrackDataStatus, TrackName, TrackVisibility} from "./TrackSelector";
+import {DEFAULT_MUTATION_COLUMNS} from ".";
 
 export type MutationMapperProps = {
     hugoSymbol?: string;
@@ -32,7 +33,7 @@ export type MutationMapperProps = {
     windowWrapper?: {size: {width: number, height: number}};
     trackVisibility?: TrackVisibility;
     tracks?: TrackName[];
-    customMutationTableColumns?: DataTableColumn<Partial<Mutation>>[];
+    mutationTableColumns?: DataTableColumn<Partial<Mutation>>[];
     customMutationTableProps?: Partial<TableProps<Partial<Mutation>>>;
     showFilterResetPanel?: boolean;
     showPlotYMaxSlider?: boolean;
@@ -225,24 +226,32 @@ export default class MutationMapper<P extends MutationMapperProps = MutationMapp
         return undefined;
     }
 
-    protected get mutationTableComponent(): JSX.Element | null
-    {
-        return this.props.mutationTable ? this.props.mutationTable! : (
-            <DefaultMutationTable
-                dataStore={this.store.dataStore}
-                columns={this.props.customMutationTableColumns}
-                initialSortColumn={this.props.mutationTableInitialSortColumn}
-                initialSortDirection={this.props.mutationTableInitialSortDirection}
-                reactTableProps={this.props.customMutationTableProps}
-                hotspotData={this.store.indexedHotspotData}
-                oncoKbData={this.store.oncoKbData}
-                oncoKbCancerGenes={this.store.oncoKbCancerGenes}
-                oncoKbEvidenceCache={this.store.oncoKbEvidenceCache}
-                indexedMyVariantInfoAnnotations={this.store.indexedMyVariantInfoAnnotations}
-                pubMedCache={this.pubMedCache}
-                info={this.mutationTableInfo}
-            />
-        );
+    protected get mutationTableComponent(): JSX.Element | null {
+        if (this.props.mutationTable) {
+            return this.props.mutationTable!;
+        } else {
+            let columns: DataTableColumn<Partial<Mutation>>[] = DEFAULT_MUTATION_COLUMNS;
+            if (this.props.mutationTableColumns) {
+                columns = this.props.mutationTableColumns!;
+            }
+
+            return (
+                <DefaultMutationTable
+                    dataStore={this.store.dataStore}
+                    columns={columns}
+                    initialSortColumn={this.props.mutationTableInitialSortColumn}
+                    initialSortDirection={this.props.mutationTableInitialSortDirection}
+                    reactTableProps={this.props.customMutationTableProps}
+                    hotspotData={this.store.indexedHotspotData}
+                    oncoKbData={this.store.oncoKbData}
+                    oncoKbCancerGenes={this.store.oncoKbCancerGenes}
+                    oncoKbEvidenceCache={this.store.oncoKbEvidenceCache}
+                    indexedMyVariantInfoAnnotations={this.store.indexedMyVariantInfoAnnotations}
+                    pubMedCache={this.pubMedCache}
+                    info={this.mutationTableInfo}
+                />
+            );
+        }
     }
 
     protected get mutationPlot(): JSX.Element | null


### PR DESCRIPTION
- The columns should be specified if user wants to change the order of the columns
- Provide the default accessors and Cell renders 