### PR TITLE
add style map to mutation status

### DIFF
--- a/src/component/column/MutationStatus.tsx
+++ b/src/component/column/MutationStatus.tsx
@@ -9,6 +9,7 @@ type MutationStatusProps = {
     mutation?: Mutation;
     displayValueMap?: {[mutationStatus: string]: string};
     enableTooltip?: boolean;
+    styleMap?: {[mutationStatus: string]: React.CSSProperties};
 };
 
 export default class MutationStatus extends React.Component<MutationStatusProps, {}>
@@ -26,7 +27,11 @@ export default class MutationStatus extends React.Component<MutationStatusProps,
             if (value.toLowerCase().includes("somatic"))
             {
                 content = (
-                    <span className={styles.somatic}>
+                    <span
+                        className={styles.somatic}
+                        style={this.props.styleMap ?
+                            this.props.styleMap[value.toLowerCase()]: undefined}
+                    >
                         {
                             (this.props.displayValueMap && (
                                 this.props.displayValueMap[value.toLowerCase()] || this.props.displayValueMap["somatic"]
@@ -39,7 +44,11 @@ export default class MutationStatus extends React.Component<MutationStatusProps,
             else if (value.toLowerCase().includes("germline"))
             {
                 content = (
-                    <span className={styles.germline}>
+                    <span
+                        className={styles.germline}
+                        style={this.props.styleMap ?
+                            this.props.styleMap[value.toLowerCase()]: undefined}
+                    >
                         {
                             (this.props.displayValueMap && (
                                 this.props.displayValueMap[value.toLowerCase()] || this.props.displayValueMap["germline"]


### PR DESCRIPTION
tried in msk insight, for example set benign to green and pathogenic to blue:
![image](https://user-images.githubusercontent.com/16869603/65712471-1dee8380-e065-11e9-9288-e1490e4dc871.png)
