### PR TITLE
improved y-axis max calculation and slider behavior

### DIFF
--- a/src/LollipopMutationPlotControls.tsx
+++ b/src/LollipopMutationPlotControls.tsx
@@ -5,6 +5,7 @@ import Slider from 'react-rangeslider'
 import {computed} from "mobx";
 import {observer} from "mobx-react";
 
+import {getYAxisMaxSliderValue} from "./util/LollipopPlotUtils";
 import TrackSelector, {TrackDataStatus, TrackName, TrackVisibility} from "./TrackSelector";
 
 import "react-rangeslider/lib/index.css";
@@ -26,7 +27,6 @@ type LollipopMutationPlotControlsProps = {
     yMaxSlider: number;
     yMaxSliderStep: number;
     yMaxInput: number;
-    yMaxFractionDigits?: number;
     bottomYMaxSlider?: number;
     bottomYMaxSliderStep: number;
     bottomYMaxInput?: number;
@@ -42,16 +42,6 @@ type LollipopMutationPlotControlsProps = {
     getSVG: () => SVGElement;
 };
 
-function formatSliderValue(value: number, step: number, coeff: number, fractionDigits: number = 4)
-{
-    return step < 1 ? Number(value.toFixed(fractionDigits))  + coeff * step: value;
-}
-
-function formatInputValue(value: number, step: number, fractionDigits: number = 4)
-{
-    return step < 1 ? value.toFixed(fractionDigits): value.toString();
-}
-
 @observer
 export default class LollipopMutationPlotControls extends React.Component<LollipopMutationPlotControlsProps, {}>
 {
@@ -59,8 +49,7 @@ export default class LollipopMutationPlotControls extends React.Component<Lollip
         showTrackSelector: true,
         showYMaxSlider: true,
         showLegendToggle: true,
-        showDownloadControls: true,
-        yMaxFractionDigits: 2
+        showDownloadControls: true
     };
 
     @computed
@@ -94,12 +83,8 @@ export default class LollipopMutationPlotControls extends React.Component<Lollip
                     }}
                 >
                     <Slider
-                        min={Math.max(0,
-                            formatSliderValue(countRange[0], yMaxSliderStep, -1, this.props.yMaxFractionDigits))
-                        }
-                        max={
-                            formatSliderValue(countRange[1], yMaxSliderStep, 1, this.props.yMaxFractionDigits)
-                        }
+                        min={yMaxSliderStep}
+                        max={getYAxisMaxSliderValue(yMaxSliderStep, countRange)}
                         tooltip={false}
                         step={yMaxSliderStep}
                         onChange={onYAxisMaxSliderChange}
@@ -108,7 +93,7 @@ export default class LollipopMutationPlotControls extends React.Component<Lollip
                 </div>
                 <EditableSpan
                     className={styles["ymax-number-input"]}
-                    value={formatInputValue(yMaxInput, yMaxSliderStep, this.props.yMaxFractionDigits)}
+                    value={`${yMaxInput}`}
                     setValue={onYAxisMaxChange}
                     numericOnly={yMaxSliderStep >= 1}
                     onFocus={this.props.onYMaxInputFocused}

--- a/src/util/LollipopPlotUtils.ts
+++ b/src/util/LollipopPlotUtils.ts
@@ -61,15 +61,16 @@ export function lollipopLabelTextAnchor(labelText: string,
     return anchor;
 }
 
-export function getYAxisMaxSliderValue(value: number, countRange: [number, number])
-{
-    return value < countRange[0] ? countRange[0] : value;
+export function getYAxisMaxSliderValue(yMaxStep: number, countRange: number[], yMaxInput?: number) {
+    const defaultMin = yMaxStep * Math.ceil(countRange[1] / yMaxStep);
+    // we don't want max slider value to go over the actual max, even if the user input goes over it
+    return Math.min(defaultMin, yMaxInput || defaultMin);
 }
 
-export function getYAxisMaxInputValue(input: string, countRange: [number, number])
+export function getYAxisMaxInputValue(yMaxStep: number, input: string)
 {
     const value = parseFloat(input);
-    return value < countRange[0] ? countRange[0] : value;
+    return value < yMaxStep ? yMaxStep : value;
 }
 
 export function calcCountRange(lollipops: LollipopSpec[],


### PR DESCRIPTION
- By default only providing one digit precision for decimal y-axis values
- Setting the initial y-max value to the multiples of the step (`0.1` by default) instead of the actual maximum.

Before:
![slider_precision_before](https://user-images.githubusercontent.com/3604198/66343968-b6fd8400-e91a-11e9-9c45-0acace4d4a5f.png)

After:
![slider_precision](https://user-images.githubusercontent.com/3604198/66343574-e8c21b00-e919-11e9-8c6b-b3fddbccbb81.png)
