### PR TITLE
Lollipop stick starts from the gene center by default

### DIFF
--- a/src/LollipopPlot.tsx
+++ b/src/LollipopPlot.tsx
@@ -27,6 +27,7 @@ export type LollipopPlotProps = {
     groups?: string[];
     topYAxisSymbol?: string;
     bottomYAxisSymbol?: string;
+    zeroStickBaseY?: boolean;
     hugoGeneSymbol: string;
     dataStore: DataStore;
     onXAxisOffset?: (offset: number) => void;

--- a/src/LollipopPlotNoTooltip.tsx
+++ b/src/LollipopPlotNoTooltip.tsx
@@ -461,16 +461,20 @@ export default class LollipopPlotNoTooltip extends React.Component<LollipopPlotN
         return sequenceComponents;
     }
 
+    @computed private get zeroHeight() {
+        // we need to add a non-zero value if the stick needs to start from the gene center
+        return this.props.zeroStickBaseY ? 0: this.domainPadding + this.domainHeight / 2;
+    }
+
     @computed private get lollipops() {
         this.lollipopComponents = {};
         const hoverHeadRadius = 5;
         return this.props.lollipops.map((lollipop:LollipopSpec, i:number) => {
             const stickHeight = lollipop.placement === LollipopPlacement.BOTTOM ?
-                -this.countToHeight(lollipop.count, this.bottomYMax) :
-                this.countToHeight(lollipop.count, this.yMax);
+                -this.countToHeight(lollipop.count, this.bottomYMax, this.zeroHeight) :
+                this.countToHeight(lollipop.count, this.yMax, this.zeroHeight);
 
-            const stickBaseY = lollipop.placement === LollipopPlacement.BOTTOM ?
-                this.bottomYAxisY : this.yAxisY + this.yAxisHeight;
+            const stickBaseY = this.calcStickBaseY(lollipop.placement);
 
             return (
                 <Lollipop
@@ -592,6 +596,19 @@ export default class LollipopPlotNoTooltip extends React.Component<LollipopPlotN
 
     @computed public get svgHeight() {
         return this.needBottomPlacement ? 2 * this.props.vizHeight : this.props.vizHeight;
+    }
+
+    private calcStickBaseY(placement?: LollipopPlacement)
+    {
+        // by default start from the center of the plot
+        let stickBaseY = this.geneCenterY;
+
+        // calculation needed when the stick starts from the axis zero (above domains)
+        if (this.props.zeroStickBaseY) {
+            stickBaseY = placement === LollipopPlacement.BOTTOM ? this.bottomYAxisY : this.yAxisY + this.yAxisHeight;
+        }
+
+        return stickBaseY;
     }
 
     private makeDomainIndexClass(index:number) {


### PR DESCRIPTION
Lollipop sticks start from gene center:
![lollipop_stick_center](https://user-images.githubusercontent.com/3604198/66402917-b36a0b80-e9b3-11e9-92e9-3266d5969966.png)

Lollipop sticks start from y-axis zero:
![lollipop_stick_zero](https://user-images.githubusercontent.com/3604198/66402925-b6fd9280-e9b3-11e9-9aeb-984b26f27bf8.png)
