### PR TITLE
Excluding the protein impact type filter when counting mutations

### DIFF
--- a/src/store/DefaultMutationMapperDataStore.ts
+++ b/src/store/DefaultMutationMapperDataStore.ts
@@ -6,7 +6,7 @@ import {DataFilter, DataFilterType} from "../model/DataFilter";
 import DataStore from "../model/DataStore";
 import {FilterApplier} from "../model/FilterApplier";
 import {Mutation} from "../model/Mutation";
-import {groupDataByGroupFilters, indexPositions} from "../util/FilterUtils";
+import {applyDataFiltersOnDatum, groupDataByGroupFilters, indexPositions} from "../util/FilterUtils";
 
 type GroupedData = Array<{group: string, data: Array<Mutation | Mutation[]>}>;
 
@@ -64,7 +64,7 @@ export class DefaultMutationMapperDataStore implements DataStore
     @computed
     public get sortedFilteredGroupedData(): GroupedData
     {
-        return groupDataByGroupFilters(this.groupFilters, this, this.applyFilter);
+        return groupDataByGroupFilters(this.groupFilters, this.sortedFilteredData, this.applyFilter);
     }
 
     @computed
@@ -135,32 +135,17 @@ export class DefaultMutationMapperDataStore implements DataStore
 
     public dataMainFilter(mutation: Mutation): boolean
     {
-        return (
-            this.dataFilters.length > 0 &&
-            !this.dataFilters
-                .map(dataFilter => this.applyFilter(dataFilter, mutation))
-                .includes(false)
-        );
+        return applyDataFiltersOnDatum(mutation, this.dataFilters, this.applyFilter);
     }
 
     public dataSelectFilter(mutation: Mutation): boolean
     {
-        return (
-            this.selectionFilters.length > 0 &&
-            !this.selectionFilters
-                .map(dataFilter => this.applyFilter(dataFilter, mutation))
-                .includes(false)
-        );
+        return applyDataFiltersOnDatum(mutation, this.selectionFilters, this.applyFilter);
     }
 
     public dataHighlightFilter(mutation: Mutation): boolean
     {
-        return (
-            this.highlightFilters.length > 0 &&
-            !this.highlightFilters
-                .map(dataFilter => this.applyFilter(dataFilter, mutation))
-                .includes(false)
-        );
+        return applyDataFiltersOnDatum(mutation,this.highlightFilters, this.applyFilter);
     }
 
     @autobind

--- a/src/util/FilterUtils.ts
+++ b/src/util/FilterUtils.ts
@@ -127,18 +127,18 @@ export function applyDefaultMutationFilter(filter: MutationFilter, mutation: Mut
 }
 
 export function groupDataByGroupFilters(groupFilters: {group: string, filter: DataFilter}[],
-                                        dataStore: DataStore,
+                                        sortedFilteredData: any[],
                                         applyFilter: ApplyFilterFn)
 {
     return groupFilters.map(groupFilter => ({
         group: groupFilter.group,
-        data: dataStore.sortedFilteredData.filter(
+        data: sortedFilteredData.filter(
             // TODO simplify array flatten if possible
             m => applyFilter(groupFilter.filter, _.flatten([m])[0]))
     }));
 }
 
-export function groupDataByProteinImpactType(dataStore: DataStore)
+export function groupDataByProteinImpactType(sortedFilteredData: any[])
 {
     const filters = Object.keys(ProteinImpactType).map(key => ({
         group: ProteinImpactType[key],
@@ -148,7 +148,7 @@ export function groupDataByProteinImpactType(dataStore: DataStore)
         }
     }));
 
-    const groupedData = groupDataByGroupFilters(filters, dataStore, applyDefaultProteinImpactTypeFilter);
+    const groupedData = groupDataByGroupFilters(filters, sortedFilteredData, applyDefaultProteinImpactTypeFilter);
 
     return _.keyBy(groupedData, d => d.group);
 }
@@ -177,4 +177,19 @@ export function onFilterOptionSelect(selectedValues: string[],
         // replace the existing data filter wrt the current selection (other filters + new data filter)
         dataStore.setDataFilters([...otherFilters, dataFilter]);
     }
+}
+
+export function applyDataFiltersOnDatum(datum: any, dataFilters: DataFilter[], applyFilter: ApplyFilterFn) {
+    return (
+        dataFilters.length > 0 &&
+        !dataFilters
+            .map(dataFilter => applyFilter(dataFilter, datum))
+            .includes(false)
+    );
+}
+
+export function applyDataFilters(data: any[], dataFilters: DataFilter[], applyFilter: ApplyFilterFn) {
+    return dataFilters.length > 0 ? data.filter(
+        m => applyDataFiltersOnDatum(m, dataFilters, applyFilter)
+    ): data;
 }


### PR DESCRIPTION
When counting mutations by protein impact type excluding the protein impact type filter itself. Only applying other filters.

![mutation_type_unfiltered_counts](https://user-images.githubusercontent.com/3604198/66742525-d0845b80-ee45-11e9-9684-fb5e0763bcfb.png)
