### PR TITLE
Removed checkboxes from protein impact type selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-mutation-mapper",
-  "version": "0.3.0-beta.9",
+  "version": "0.3.0-beta.10",
   "description": "Generic Mutation Mapper",
   "author": "cBioPortal",
   "license": "GNU Affero General Public License v3.0",

--- a/src/component/filter/BadgeLabel.tsx
+++ b/src/component/filter/BadgeLabel.tsx
@@ -6,36 +6,75 @@ export type BadgeLabelProps = {
     badgeContent?: number | string;
     badgeStyleOverride?: CSSProperties;
     badgeClassName?: string;
+    badgeFirst?: boolean;
 };
 
 export const DEFAULT_BADGE_STYLE = {
     color: "#FFF",
-    backgroundColor: "#000",
-    marginLeft: 5,
+    backgroundColor: "#000"
 };
 
 export class BadgeLabel extends React.Component<BadgeLabelProps, {}>
 {
     public static defaultProps: Partial<BadgeLabelProps> = {
-        badgeClassName: "badge"
+        badgeClassName: "badge",
+        badgeFirst: false
     };
+
+    protected get badgeStyle()
+    {
+        if (this.props.badgeFirst) {
+            return {
+                ...DEFAULT_BADGE_STYLE,
+                marginRight: 5,
+            };
+        }
+        else {
+            return {
+                ...DEFAULT_BADGE_STYLE,
+                marginLeft: 5,
+            };
+        }
+    }
+
+    protected get badge(): JSX.Element
+    {
+        return (
+            <span
+                className={this.props.badgeClassName}
+                style={{
+                    ...this.badgeStyle,
+                    ...this.props.badgeStyleOverride
+                }}
+            >
+                {this.props.badgeContent}
+            </span>
+        );
+    }
+
+    protected get badgeFirst(): JSX.Element
+    {
+        return (
+            <React.Fragment>
+                {this.badge}
+                {this.props.label}
+            </React.Fragment>
+        );
+    }
+
+    protected get badgeLast(): JSX.Element
+    {
+        return (
+            <React.Fragment>
+                {this.props.label}
+                {this.badge}
+            </React.Fragment>
+        );
+    }
 
     public render(): JSX.Element
     {
-        return (
-            <span>
-            {this.props.label}
-                <span
-                    className={this.props.badgeClassName}
-                    style={{
-                        ...DEFAULT_BADGE_STYLE,
-                        ...this.props.badgeStyleOverride
-                    }}
-                >
-                    {this.props.badgeContent}
-                </span>
-            </span>
-        );
+        return this.props.badgeFirst ? this.badgeFirst: this.badgeLast;
     }
 }
 

--- a/src/component/filter/BadgeSelector.tsx
+++ b/src/component/filter/BadgeSelector.tsx
@@ -26,6 +26,7 @@ export type BadgeSelectorProps = {
     getOptionLabel?: (option: Option,
                       selectedValues: {[optionValue: string]: any},
                       checkBoxType?: CheckBoxType) => JSX.Element;
+    getBadgeLabel?: (option: BadgeSelectorOption, badgeClassName?: string) => JSX.Element;
     filter?: DataFilter<string>;
     options?: BadgeSelectorOption[];
     badgeClassName?: string;
@@ -45,17 +46,23 @@ export class BadgeSelector extends React.Component<BadgeSelectorProps, {}>
         return this.props.selectedValues || getSelectedOptionValues(this.allValues, this.props.filter);
     }
 
+    public getBadgeLabel(option: BadgeSelectorOption, badgeClassName?: string): JSX.Element {
+        return this.props.getBadgeLabel ?
+            this.props.getBadgeLabel(option, badgeClassName): (
+                <BadgeLabel
+                    label={option.label || option.value}
+                    badgeContent={option.badgeContent}
+                    badgeStyleOverride={option.badgeStyleOverride}
+                    badgeClassName={this.props.badgeClassName}
+                />
+            );
+    }
+
     @computed
     public get options(): Option[] {
         return (this.props.options || [])
             .map(option => ({
-                label:
-                    <BadgeLabel
-                        label={option.label || option.value}
-                        badgeContent={option.badgeContent}
-                        badgeStyleOverride={option.badgeStyleOverride}
-                        badgeClassName={this.props.badgeClassName}
-                    />,
+                label: this.getBadgeLabel(option, this.props.badgeClassName),
                 value: option.value
             }));
     }

--- a/src/component/filter/ProteinImpactTypeBadgeSelector.tsx
+++ b/src/component/filter/ProteinImpactTypeBadgeSelector.tsx
@@ -1,11 +1,12 @@
-import {ProteinImpactType} from "cbioportal-frontend-commons";
+import {Option, ProteinImpactType} from "cbioportal-frontend-commons";
 import {computed} from "mobx";
 import {observer} from "mobx-react";
 import * as React from 'react';
 
 import {IProteinImpactTypeColors} from "../../model/ProteinImpact";
 import {DEFAULT_PROTEIN_IMPACT_TYPE_COLORS} from "../../util/MutationUtils";
-import BadgeSelector, {BadgeSelectorProps} from "./BadgeSelector";
+import {BadgeLabel} from "./BadgeLabel";
+import BadgeSelector, {BadgeSelectorOption, BadgeSelectorProps} from "./BadgeSelector";
 import {getProteinImpactTypeColorMap, getProteinImpactTypeOptionDisplayValueMap} from "./ProteinImpactTypeHelper";
 
 export type ProteinImpactTypeBadgeSelectorProps = BadgeSelectorProps &
@@ -20,6 +21,37 @@ const VALUES = [
     ProteinImpactType.INFRAME,
     ProteinImpactType.OTHER
 ];
+
+export function getProteinImpactTypeOptionLabel(option: Option,
+                                                selectedValues: {[optionValue: string]: any}): JSX.Element
+{
+    const isSelected = option.value in selectedValues;
+
+    return (
+        <span
+            style={{
+                opacity: isSelected ? undefined: 0.4,
+                textDecoration: isSelected ? undefined: "line-through"
+            }}
+        >
+            {option.label || option.value}
+        </span>
+    );
+}
+
+export function getProteinImpactTypeBadgeLabel(option: BadgeSelectorOption,
+                                               badgeClassName?: string): JSX.Element
+{
+    return (
+        <BadgeLabel
+            label={option.label || option.value}
+            badgeContent={option.badgeContent}
+            badgeStyleOverride={option.badgeStyleOverride}
+            badgeClassName={badgeClassName}
+            badgeFirst={true}
+        />
+    );
+}
 
 @observer
 export class ProteinImpactTypeBadgeSelector extends React.Component<ProteinImpactTypeBadgeSelectorProps, {}>
@@ -56,6 +88,8 @@ export class ProteinImpactTypeBadgeSelector extends React.Component<ProteinImpac
         return (
             <BadgeSelector
                 options={this.options}
+                getOptionLabel={getProteinImpactTypeOptionLabel}
+                getBadgeLabel={getProteinImpactTypeBadgeLabel}
                 {...this.props}
             />
         );


### PR DESCRIPTION
![badge-selector-fade-out-strike](https://user-images.githubusercontent.com/3604198/66957720-beb4db00-f034-11e9-82b0-8f7e0d3f5c93.png)


- Removed checkboxes from protein impact type selector
- When unselected fading out the type