### PR TITLE
Replaced fade out style with empty badge style for protein impact type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-mutation-mapper",
-  "version": "0.3.0-beta.11",
+  "version": "0.3.0-beta.12",
   "description": "Generic Mutation Mapper",
   "author": "cBioPortal",
   "license": "GNU Affero General Public License v3.0",

--- a/src/component/filter/BadgeLabel.tsx
+++ b/src/component/filter/BadgeLabel.tsx
@@ -11,7 +11,9 @@ export type BadgeLabelProps = {
 
 export const DEFAULT_BADGE_STYLE = {
     color: "#FFF",
-    backgroundColor: "#000"
+    backgroundColor: "#000",
+    borderStyle: "solid",
+    borderWidth: "thin"
 };
 
 export class BadgeLabel extends React.Component<BadgeLabelProps, {}>

--- a/src/component/filter/BadgeSelector.tsx
+++ b/src/component/filter/BadgeSelector.tsx
@@ -1,5 +1,5 @@
 import autobind from "autobind-decorator";
-import {CheckBoxType, Checklist, Option} from "cbioportal-frontend-commons";
+import {CheckBoxType, Checklist, getSelectedValuesMap, Option} from "cbioportal-frontend-commons";
 import {action, computed} from "mobx";
 import {observer} from "mobx-react";
 import * as React from 'react';
@@ -7,13 +7,14 @@ import {CSSProperties} from "react";
 
 import {DataFilter} from "../../model/DataFilter";
 import {getAllOptionValues, getSelectedOptionValues, handleOptionSelect} from "../../util/SelectorUtils";
-import {BadgeLabel} from "./BadgeLabel";
+import {BadgeLabel, DEFAULT_BADGE_STYLE} from "./BadgeLabel";
 
 export type BadgeSelectorOption = {
     value: string;
     label?: string | JSX.Element;
     badgeContent?: number | string;
     badgeStyleOverride?: CSSProperties;
+    badgeStyleSelectedOverride?: CSSProperties;
 };
 
 export type BadgeSelectorProps = {
@@ -26,12 +27,32 @@ export type BadgeSelectorProps = {
     getOptionLabel?: (option: Option,
                       selectedValues: {[optionValue: string]: any},
                       checkBoxType?: CheckBoxType) => JSX.Element;
-    getBadgeLabel?: (option: BadgeSelectorOption, badgeClassName?: string) => JSX.Element;
+    getBadgeLabel?: (option: BadgeSelectorOption,
+                     selectedValues: {[optionValue: string]: any},
+                     badgeClassName?: string) => JSX.Element;
     filter?: DataFilter<string>;
     options?: BadgeSelectorOption[];
     badgeClassName?: string;
 };
 
+export function getBadgeStyleOverride(option: BadgeSelectorOption, selectedValues: {[optionValue: string]: any})
+{
+    let override = option.badgeStyleOverride;
+    const defaultStyle = {...DEFAULT_BADGE_STYLE, ...override};
+    const isSelected = option.value in selectedValues;
+
+    if (!isSelected)
+    {
+        // by default swap background color and text color for unselected options
+        override = option.badgeStyleSelectedOverride || {
+            color: defaultStyle.backgroundColor,
+            backgroundColor: defaultStyle.color,
+            borderColor: defaultStyle.backgroundColor
+        }
+    }
+
+    return override;
+}
 
 @observer
 export class BadgeSelector extends React.Component<BadgeSelectorProps, {}>
@@ -46,13 +67,21 @@ export class BadgeSelector extends React.Component<BadgeSelectorProps, {}>
         return this.props.selectedValues || getSelectedOptionValues(this.allValues, this.props.filter);
     }
 
-    public getBadgeLabel(option: BadgeSelectorOption, badgeClassName?: string): JSX.Element {
+    @computed
+    public get selectedValuesMap(): {[optionValue: string]: any} {
+        return getSelectedValuesMap(this.selectedValues);
+    }
+
+    public getBadgeLabel(option: BadgeSelectorOption,
+                         selectedValues: {[optionValue: string]: any},
+                         badgeClassName?: string): JSX.Element
+    {
         return this.props.getBadgeLabel ?
-            this.props.getBadgeLabel(option, badgeClassName): (
+            this.props.getBadgeLabel(option, selectedValues, badgeClassName): (
                 <BadgeLabel
                     label={option.label || option.value}
                     badgeContent={option.badgeContent}
-                    badgeStyleOverride={option.badgeStyleOverride}
+                    badgeStyleOverride={getBadgeStyleOverride(option, selectedValues)}
                     badgeClassName={this.props.badgeClassName}
                 />
             );
@@ -62,7 +91,7 @@ export class BadgeSelector extends React.Component<BadgeSelectorProps, {}>
     public get options(): Option[] {
         return (this.props.options || [])
             .map(option => ({
-                label: this.getBadgeLabel(option, this.props.badgeClassName),
+                label: this.getBadgeLabel(option, this.selectedValuesMap, this.props.badgeClassName),
                 value: option.value
             }));
     }

--- a/src/component/filter/MutationStatusBadgeSelector.tsx
+++ b/src/component/filter/MutationStatusBadgeSelector.tsx
@@ -11,18 +11,26 @@ export type MutationStatusBadgeSelectorProps = BadgeSelectorProps &
     badgeSelectorOptions?: BadgeSelectorOption[];
 };
 
+export const MUTATION_STATUS_BADGE_STYLE_OVERRIDE = {
+    color: "#000",
+    backgroundColor: "#FFF",
+    borderColor: "#FFF"
+};
+
 export function getMutationStatusFilterOptions()
 {
     return [
         {
             value: "somatic",
             label: "Somatic Mutation Frequency",
-            badgeStyleOverride: {color: "#000", backgroundColor: "#CCFFFF"}
+            badgeStyleOverride: MUTATION_STATUS_BADGE_STYLE_OVERRIDE,
+            badgeStyleSelectedOverride: MUTATION_STATUS_BADGE_STYLE_OVERRIDE
         },
         {
             value: "germline",
             label: "Germline Mutation Frequency",
-            badgeStyleOverride: {color: "#000", backgroundColor: "#FFFFCC"}
+            badgeStyleOverride: MUTATION_STATUS_BADGE_STYLE_OVERRIDE,
+            badgeStyleSelectedOverride: MUTATION_STATUS_BADGE_STYLE_OVERRIDE
         }
     ];
 }

--- a/src/component/filter/ProteinImpactTypeBadgeSelector.tsx
+++ b/src/component/filter/ProteinImpactTypeBadgeSelector.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import {IProteinImpactTypeColors} from "../../model/ProteinImpact";
 import {DEFAULT_PROTEIN_IMPACT_TYPE_COLORS} from "../../util/MutationUtils";
 import {BadgeLabel} from "./BadgeLabel";
-import BadgeSelector, {BadgeSelectorOption, BadgeSelectorProps} from "./BadgeSelector";
+import BadgeSelector, {BadgeSelectorOption, BadgeSelectorProps, getBadgeStyleOverride} from "./BadgeSelector";
 import {getProteinImpactTypeColorMap, getProteinImpactTypeOptionDisplayValueMap} from "./ProteinImpactTypeHelper";
 
 export type ProteinImpactTypeBadgeSelectorProps = BadgeSelectorProps &
@@ -22,31 +22,20 @@ const VALUES = [
     ProteinImpactType.OTHER
 ];
 
-export function getProteinImpactTypeOptionLabel(option: Option,
-                                                selectedValues: {[optionValue: string]: any}): JSX.Element
+export function getProteinImpactTypeOptionLabel(option: Option): JSX.Element
 {
-    const isSelected = option.value in selectedValues;
-
-    return (
-        <span
-            style={{
-                opacity: isSelected ? undefined: 0.4,
-                textDecoration: isSelected ? undefined: "line-through"
-            }}
-        >
-            {option.label || option.value}
-        </span>
-    );
+    return <span>{option.label || option.value}</span>;
 }
 
 export function getProteinImpactTypeBadgeLabel(option: BadgeSelectorOption,
+                                               selectedValues: {[optionValue: string]: any},
                                                badgeClassName?: string): JSX.Element
 {
     return (
         <BadgeLabel
             label={option.label || option.value}
             badgeContent={option.badgeContent}
-            badgeStyleOverride={option.badgeStyleOverride}
+            badgeStyleOverride={getBadgeStyleOverride(option, selectedValues)}
             badgeClassName={badgeClassName}
             badgeFirst={true}
         />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -37,7 +37,8 @@ export {
 } from "./component/filter/ProteinImpactTypeBadgeSelector";
 export {
     default as MutationStatusBadgeSelector,
-    MutationStatusBadgeSelectorProps
+    MUTATION_STATUS_BADGE_STYLE_OVERRIDE,
+    MutationStatusBadgeSelectorProps,
 } from "./component/filter/MutationStatusBadgeSelector";
 
 export {


### PR DESCRIPTION
![mutation_type_selector](https://user-images.githubusercontent.com/3604198/67777131-ad59ce80-fa37-11e9-8c83-be25d58659bc.png)
