### PR TITLE
Fixed column header tooltip issues

### DIFF
--- a/src/component/column/ColumnHeader.tsx
+++ b/src/component/column/ColumnHeader.tsx
@@ -14,13 +14,7 @@ class ColumnHeader extends React.Component<ColumnHeaderProps>
     };
 
     public render() {
-        let content= (
-            <span
-                className={this.props.className || ColumnHeader.defaultProps.className}
-            >
-                {this.props.headerContent}
-            </span>
-        );
+        let content= this.props.headerContent;
 
         if (this.props.overlay)
         {
@@ -36,7 +30,13 @@ class ColumnHeader extends React.Component<ColumnHeaderProps>
             );
         }
 
-        return content;
+        return (
+            <span
+                className={this.props.className || ColumnHeader.defaultProps.className}
+            >
+                {content}
+            </span>
+        );
     }
 }
 


### PR DESCRIPTION
Before:
![column-header-misaligned-tooltip](https://user-images.githubusercontent.com/3604198/67849144-670a7b00-fadc-11e9-841d-3d25c67f75a3.png)

After:
![column-header-correct-aligned-tooltip](https://user-images.githubusercontent.com/3604198/67849150-6b369880-fadc-11e9-8098-4b6f22fa2760.png)
