### PR TITLE
Moved filter reset panel into lollipop mutation controls panel

### DIFF
--- a/src/LollipopMutationPlot.tsx
+++ b/src/LollipopMutationPlot.tsx
@@ -67,6 +67,7 @@ export type LollipopMutationPlotProps = {
     showYMaxSlider?: boolean;
     showLegendToggle?: boolean;
     showDownloadControls?: boolean;
+    filterResetPanel?: JSX.Element;
     legend?: JSX.Element;
     loadingIndicator?: JSX.Element;
 };
@@ -519,6 +520,7 @@ export default class LollipopMutationPlot extends React.Component<LollipopMutati
                         bottomYMaxSliderStep={this.bottomYMaxSliderStep}
                         bottomYMaxInput={this.bottomYMaxInput}
                         customControls={this.props.customControls}
+                        filterResetPanel={this.props.filterResetPanel}
                         trackVisibility={this.trackVisibility}
                         tracks={this.props.tracks}
                         trackDataStatus={this.props.trackDataStatus}

--- a/src/LollipopMutationPlotControls.tsx
+++ b/src/LollipopMutationPlotControls.tsx
@@ -28,12 +28,14 @@ type LollipopMutationPlotControlsProps = {
     onToggleLegend: () => void;
     yMaxSlider: number;
     yMaxSliderStep: number;
+    yMaxSliderWidth: number;
     yMaxInput: number;
     yAxisSameScale?: boolean;
     bottomYMaxSlider?: number;
     bottomYMaxSliderStep: number;
     bottomYMaxInput?: number;
     customControls?: JSX.Element;
+    filterResetPanel?: JSX.Element;
     tracks?: TrackName[];
     trackVisibility?: TrackVisibility;
     trackDataStatus?: TrackDataStatus;
@@ -60,7 +62,8 @@ export default class LollipopMutationPlotControls extends React.Component<Lollip
         showTrackSelector: true,
         showYMaxSlider: true,
         showLegendToggle: true,
-        showDownloadControls: true
+        showDownloadControls: true,
+        yMaxSliderWidth: 100
     };
 
     @computed
@@ -128,7 +131,7 @@ export default class LollipopMutationPlotControls extends React.Component<Lollip
             this.props.yMaxInput,
             this.props.yAxisSameScale,
             this.showBottomYAxisSlider ? "Top Y-Axis Max" : "Y-Axis Max",
-            this.showBottomYAxisSlider ? 100 : 200,
+            this.props.yMaxSliderWidth,
             this.props.yMaxSliderStep);
     }
 
@@ -206,6 +209,7 @@ export default class LollipopMutationPlotControls extends React.Component<Lollip
                     {this.props.trackVisibility && this.props.onTrackVisibilityChange && this.props.showTrackSelector && this.trackSelector}
                     {this.props.showYMaxSlider && this.yMaxSlider}
                     {this.props.showYMaxSlider && this.bottomYMaxSlider}
+                    {this.props.filterResetPanel}
                     {this.props.customControls}
                     <div style={{display: "flex", marginLeft: "auto"}}>
                         {this.props.showLegendToggle && this.legendToggle}

--- a/src/MutationMapper.tsx
+++ b/src/MutationMapper.tsx
@@ -276,6 +276,10 @@ export default class MutationMapper<P extends MutationMapperProps = MutationMapp
                 showYMaxSlider={this.props.showPlotYMaxSlider}
                 showLegendToggle={this.props.showPlotLegendToggle}
                 showDownloadControls={this.props.showPlotDownloadControls}
+                filterResetPanel={
+                    this.props.showFilterResetPanel && this.isFiltered && this.filterResetPanel ?
+                        this.filterResetPanel: undefined
+                }
                 trackDataStatus={this.trackDataStatus}
                 showTrackSelector={this.props.showTrackSelector}
                 onXAxisOffset={this.onXAxisOffset}
@@ -354,10 +358,10 @@ export default class MutationMapper<P extends MutationMapperProps = MutationMapp
 
         return (
             <FilterResetPanel
-                filterInfo={`${tableData.length}/${allData.length} mutations are shown based on current filtering.`}
+                filterInfo={`Showing ${tableData.length} of ${allData.length} mutations.`}
                 resetFilters={this.resetFilters}
             />
-        )
+        );
     }
 
     protected get mutationTable(): JSX.Element | null
@@ -404,7 +408,6 @@ export default class MutationMapper<P extends MutationMapperProps = MutationMapp
     {
         return this.isLoading ? this.loadingIndicator : (
             <div>
-                {this.isFiltered && this.props.showFilterResetPanel && this.filterResetPanel}
                 <div style={{ display:'flex' }}>
                     <div className="borderedChart" style={{ marginRight: "1rem" }}>
                         {this.mutationPlot}

--- a/src/component/FilterResetPanel.tsx
+++ b/src/component/FilterResetPanel.tsx
@@ -16,7 +16,7 @@ type FilterResetPanelProps = {
 export class FilterResetPanel extends React.Component<FilterResetPanelProps, {}>
 {
     public static defaultProps: Partial<FilterResetPanelProps> = {
-        buttonText: "Show all mutations",
+        buttonText: "Show all",
         buttonClass: classNames("btn", "btn-secondary", "btn-sm"),
         className: classNames("alert" , "alert-success", styles.filterResetPanel),
     };

--- a/src/component/filterResetPanel.module.scss
+++ b/src/component/filterResetPanel.module.scss
@@ -1,3 +1,5 @@
 .filterResetPanel {
     padding: 0.25rem 0.75rem;
+    margin-bottom: 0 !important;
+    margin-left: 0.5rem;
 }


### PR DESCRIPTION
This is to fix the lollipop diagram shift problem when a filter is applied.

![filter-reset-panel](https://user-images.githubusercontent.com/3604198/67945321-026f1f00-fbb5-11e9-8f00-c0df8fb494b0.png)

@alisman We don't have fade in/out effect for the information box yet though.