### PR TITLE
Centering filter reset panel within the lollipop plots container

### DIFF
--- a/src/component/mutationMapper/filterResetPanel.module.scss
+++ b/src/component/mutationMapper/filterResetPanel.module.scss
@@ -1,5 +1,5 @@
 .filterResetPanel {
     padding: 0.25rem 0.75rem;
     margin-bottom: 0 !important;
-    margin-left: 0.5rem;
+    margin-left: auto;
 }


### PR DESCRIPTION
Before (left-aligned):
![filter_reset_left_aligned](https://user-images.githubusercontent.com/3604198/69076742-18c50980-0a02-11ea-8b68-43ab86a85e6a.png)

After (center-aligned):
![filter_reset_center_aligned](https://user-images.githubusercontent.com/3604198/69076799-3d20e600-0a02-11ea-8849-83ca8459b130.png)
