### PR TITLE
Remove scientific notation in gnomad

### DIFF
--- a/src/component/gnomad/GnomadFrequency.tsx
+++ b/src/component/gnomad/GnomadFrequency.tsx
@@ -145,7 +145,7 @@ export default class GnomadFrequency extends React.Component<GnomadFrequencyProp
             if (result["Total"].alleleFrequency === 0) {
                 display = <span>0</span>;
             } else {
-                display = <span>{parseFloat(result["Total"].alleleFrequency.toString()).toExponential(1)}</span>;
+                display = <span>{result["Total"].alleleFrequency}</span>;
             }
 
             overlay = () => <GnomadFrequencyTable data={sorted} gnomadUrl={gnomadUrl} />;

--- a/src/component/gnomad/GnomadFrequencyTable.tsx
+++ b/src/component/gnomad/GnomadFrequencyTable.tsx
@@ -19,8 +19,7 @@ export function frequencyOutput(frequency: number) {
         return <span>0</span>
     }
     else {
-        // keep one digit on allele frequency and using scientific notation
-        return <span>{parseFloat(frequency.toString()).toExponential(1)}</span>;
+        return <span>{frequency}</span>;
     }
 }
 
@@ -143,7 +142,7 @@ export default class GnomadFrequencyTable extends React.Component<IGnomadFrequen
                                 <span className="pull-right mr-1" data-test="allele-frequency-data">
                                     {frequencyOutput(column.value)}
                                 </span>,
-                            width: 80
+                            width: 120
                         },
                     ]}
                 />


### PR DESCRIPTION
please review after we confirm it on genome nexus meeting

remove scientific notation in gnomad, example in genome nexus:

![image](https://user-images.githubusercontent.com/16869603/69678462-9bd60780-1073-11ea-81c2-520ef89a3a92.png)
