### PR TITLE
Aligned badge selector content per column

### DIFF
--- a/src/component/filter/BadgeLabel.tsx
+++ b/src/component/filter/BadgeLabel.tsx
@@ -23,33 +23,21 @@ export class BadgeLabel extends React.Component<BadgeLabelProps, {}>
         badgeFirst: false
     };
 
-    protected get badgeStyle()
-    {
-        if (this.props.badgeFirst) {
-            return {
-                ...DEFAULT_BADGE_STYLE,
-                marginRight: 5,
-            };
-        }
-        else {
-            return {
-                ...DEFAULT_BADGE_STYLE,
-                marginLeft: 5,
-            };
-        }
-    }
-
     protected get badge(): JSX.Element
     {
         return (
             <span
-                className={this.props.badgeClassName}
-                style={{
-                    ...this.badgeStyle,
-                    ...this.props.badgeStyleOverride
-                }}
+                style={this.props.badgeFirst ? {marginRight: 5}: {marginLeft: 5}}
             >
-                {this.props.badgeContent}
+                <span
+                    className={this.props.badgeClassName}
+                    style={{
+                        ...DEFAULT_BADGE_STYLE,
+                        ...this.props.badgeStyleOverride
+                    }}
+                >
+                    {this.props.badgeContent}
+                </span>
             </span>
         );
     }

--- a/src/component/filter/BadgeSelector.spec.tsx
+++ b/src/component/filter/BadgeSelector.spec.tsx
@@ -1,0 +1,662 @@
+import {assert} from "chai";
+
+import {
+    BadgeSelectorOption,
+    calculateBadgeAlignmentStyle,
+    calculateBadgeAlignmentStyles,
+    DEFAULT_BADGE_CHAR_WIDTH,
+    DEFAULT_BADGE_CONTENT_PADDING
+} from "./BadgeSelector";
+
+
+describe('BadgeSelector', () => {
+
+    describe('calculateBadgeWidth', () => {
+        it("calculates badge width correctly for values of different lengths", () => {
+            assert.deepEqual(calculateBadgeAlignmentStyle( "6".length, "6".length).width,
+                (DEFAULT_BADGE_CHAR_WIDTH * 1) + (DEFAULT_BADGE_CONTENT_PADDING * 2));
+
+            assert.deepEqual(calculateBadgeAlignmentStyle( "66".length, "66".length).width,
+                (DEFAULT_BADGE_CHAR_WIDTH * 2) + (DEFAULT_BADGE_CONTENT_PADDING * 2));
+
+            assert.deepEqual(calculateBadgeAlignmentStyle( "666".length, "666".length).width,
+                (DEFAULT_BADGE_CHAR_WIDTH * 3) + (DEFAULT_BADGE_CONTENT_PADDING * 2));
+
+            assert.deepEqual(calculateBadgeAlignmentStyle( "6666".length, "6666".length).width,
+                (DEFAULT_BADGE_CHAR_WIDTH * 4) + (DEFAULT_BADGE_CONTENT_PADDING * 2));
+
+            assert.deepEqual(calculateBadgeAlignmentStyle( "66666".length, "66666".length).width,
+                (DEFAULT_BADGE_CHAR_WIDTH * 5) + (DEFAULT_BADGE_CONTENT_PADDING * 2));
+
+            assert.deepEqual(calculateBadgeAlignmentStyle( "666666".length, "666666".length).width,
+                (DEFAULT_BADGE_CHAR_WIDTH * 6) + (DEFAULT_BADGE_CONTENT_PADDING * 2));
+        });
+    });
+
+    describe('calculateBadgeWidths', () => {
+
+        const len1Width = (DEFAULT_BADGE_CHAR_WIDTH * 1) + (DEFAULT_BADGE_CONTENT_PADDING * 2);
+        const len2Width = (DEFAULT_BADGE_CHAR_WIDTH * 2) + (DEFAULT_BADGE_CONTENT_PADDING * 2);
+        const len3Width = (DEFAULT_BADGE_CHAR_WIDTH * 3) + (DEFAULT_BADGE_CONTENT_PADDING * 2);
+        const len4Width = (DEFAULT_BADGE_CHAR_WIDTH * 4) + (DEFAULT_BADGE_CONTENT_PADDING * 2);
+        const len5Width = (DEFAULT_BADGE_CHAR_WIDTH * 5) + (DEFAULT_BADGE_CONTENT_PADDING * 2);
+
+        const options: BadgeSelectorOption[] = [
+            {
+                value: "option 1",
+                badgeContent: 1
+            },
+            {
+                value: "option 2",
+                badgeContent: 222
+            },
+            {
+                value: "option 3",
+                badgeContent: 33
+            },
+            {
+                value: "option 4",
+                badgeContent: 44
+            },
+            {
+                value: "option 5",
+                badgeContent: 55555
+            },
+            {
+                value: "option 6",
+                badgeContent: 666
+            },
+            {
+                value: "option 7",
+                badgeContent: 7777
+            },
+        ];
+
+        it("returns empty array when options is empty", () => {
+            const result = calculateBadgeAlignmentStyles([], 1, false);
+            assert.deepEqual(result, []);
+        });
+
+        it("returns empty array for # columns < 1", () => {
+            const result = calculateBadgeAlignmentStyles(options, 0, false);
+            assert.deepEqual(result, []);
+        });
+
+        it("calculates badge styles for # columns = 1, alignmentWithinBadge = false", () => {
+            // columns => [1, 222, 33, 44, 55555, 666, 7777]
+            const result = calculateBadgeAlignmentStyles(options, 1, false);
+
+            // value = 1
+            assert.equal(result[0].width, len1Width);
+            assert.equal(result[0].marginLeft, (len5Width - len1Width) / 2);
+            assert.equal(result[0].marginRight, (len5Width - len1Width) / 2);
+
+            // value = 222
+            assert.equal(result[1].width, len3Width);
+            assert.equal(result[1].marginLeft, (len5Width - len3Width) / 2);
+            assert.equal(result[1].marginRight, (len5Width - len3Width) / 2);
+
+            // value = 33
+            assert.equal(result[2].width, len2Width);
+            assert.equal(result[2].marginLeft, (len5Width - len2Width) / 2);
+            assert.equal(result[2].marginRight, (len5Width - len2Width) / 2);
+
+            // value = 44
+            assert.equal(result[3].width, len2Width);
+            assert.equal(result[3].marginLeft, (len5Width - len2Width) / 2);
+            assert.equal(result[3].marginRight, (len5Width - len2Width) / 2);
+
+            // value = 55555
+            assert.equal(result[4].width, len5Width);
+            assert.equal(result[4].marginLeft, 0);
+            assert.equal(result[4].marginRight, 0);
+
+            // value = 666
+            assert.equal(result[5].width, len3Width);
+            assert.equal(result[5].marginLeft, (len5Width - len3Width) / 2);
+            assert.equal(result[5].marginRight, (len5Width - len3Width) / 2);
+
+            // value = 7777
+            assert.equal(result[6].width, len4Width);
+            assert.equal(result[6].marginLeft, (len5Width - len4Width) / 2);
+            assert.equal(result[6].marginRight, (len5Width - len4Width) / 2);
+        });
+
+        it("calculates badge styles for # columns = 1, alignmentPaddingWithinBadge = true", () => {
+            // columns => [1, 222, 33, 44, 55555, 666, 7777]
+            const result = calculateBadgeAlignmentStyles(options,
+                1,
+                false,
+                DEFAULT_BADGE_CHAR_WIDTH,
+                DEFAULT_BADGE_CONTENT_PADDING,
+                true);
+
+            assert.deepEqual(result, [
+                {width: len5Width},
+                {width: len5Width},
+                {width: len5Width},
+                {width: len5Width},
+                {width: len5Width},
+                {width: len5Width},
+                {width: len5Width}
+            ]);
+        });
+
+        it("calculates badge styles for # columns = 2, alignmentWithinBadge = false", () => {
+            // columns => [1, 33, 55555, 7777]
+            //            [222, 44, 666]
+            const result = calculateBadgeAlignmentStyles(options, 2, false);
+
+            // value = 1
+            assert.equal(result[0].width, len1Width);
+            assert.equal(result[0].marginLeft, (len5Width - len1Width) / 2);
+            assert.equal(result[0].marginRight, (len5Width - len1Width) / 2);
+
+            // value = 222
+            assert.equal(result[1].width, len3Width);
+            assert.equal(result[1].marginLeft, 0);
+            assert.equal(result[1].marginRight, 0);
+
+            // value = 33
+            assert.equal(result[2].width, len2Width);
+            assert.equal(result[2].marginLeft, (len5Width - len2Width) / 2);
+            assert.equal(result[2].marginRight, (len5Width - len2Width) / 2);
+
+            // value = 44
+            assert.equal(result[3].width, len2Width);
+            assert.equal(result[3].marginLeft, (len3Width - len2Width) / 2);
+            assert.equal(result[3].marginRight, (len3Width - len2Width) / 2);
+
+            // value = 55555
+            assert.equal(result[4].width, len5Width);
+            assert.equal(result[4].marginLeft, 0);
+            assert.equal(result[4].marginRight, 0);
+
+            // value = 666
+            assert.equal(result[5].width, len3Width);
+            assert.equal(result[5].marginLeft, 0);
+            assert.equal(result[5].marginRight, 0);
+
+            // value = 7777
+            assert.equal(result[6].width, len4Width);
+            assert.equal(result[6].marginLeft, (len5Width - len4Width) / 2);
+            assert.equal(result[6].marginRight, (len5Width - len4Width) / 2);
+        });
+
+        it("calculates badge styles for # columns = 2, alignmentPaddingWithinBadge = true", () => {
+            // columns => [1, 33, 55555, 7777]
+            //            [222, 44, 666]
+            const result = calculateBadgeAlignmentStyles(options,
+                2,
+                false,
+                DEFAULT_BADGE_CHAR_WIDTH,
+                DEFAULT_BADGE_CONTENT_PADDING,
+                true);
+
+            assert.deepEqual(result, [
+                {width: len5Width},
+                {width: len3Width},
+                {width: len5Width},
+                {width: len3Width},
+                {width: len5Width},
+                {width: len3Width},
+                {width: len5Width}
+            ]);
+        });
+
+        it("calculates badge styles for # columns = 3, alignmentPaddingWithinBadge = false", () => {
+            // columns => [1, 44, 7777]
+            //            [222, 55555]
+            //            [33, 666]
+            const result = calculateBadgeAlignmentStyles(options, 3, false);
+
+            // value = 1
+            assert.equal(result[0].width, len1Width);
+            assert.equal(result[0].marginLeft, (len4Width - len1Width) / 2);
+            assert.equal(result[0].marginRight, (len4Width - len1Width) / 2);
+
+            // value = 222
+            assert.equal(result[1].width, len3Width);
+            assert.equal(result[1].marginLeft, (len5Width - len3Width) / 2);
+            assert.equal(result[1].marginRight, (len5Width - len3Width) / 2);
+
+            // value = 33
+            assert.equal(result[2].width, len2Width);
+            assert.equal(result[2].marginLeft, (len3Width - len2Width) / 2);
+            assert.equal(result[2].marginRight, (len3Width - len2Width) / 2);
+
+            // value = 44
+            assert.equal(result[3].width, len2Width);
+            assert.equal(result[3].marginLeft, (len4Width - len2Width) / 2);
+            assert.equal(result[3].marginRight, (len4Width - len2Width) / 2);
+
+            // value = 55555
+            assert.equal(result[4].width, len5Width);
+            assert.equal(result[4].marginLeft, 0);
+            assert.equal(result[4].marginRight, 0);
+
+            // value = 666
+            assert.equal(result[5].width, len3Width);
+            assert.equal(result[5].marginLeft, 0);
+            assert.equal(result[5].marginRight, 0);
+
+            // value = 7777
+            assert.equal(result[6].width, len4Width);
+            assert.equal(result[6].marginLeft, 0);
+            assert.equal(result[6].marginRight, 0);
+        });
+
+        it("calculates badge styles for # columns = 3, alignmentPaddingWithinBadge = true", () => {
+            // columns => [1, 44, 7777]
+            //            [222, 55555]
+            //            [33, 666]
+            const result = calculateBadgeAlignmentStyles(options,
+                3,
+                false,
+                DEFAULT_BADGE_CHAR_WIDTH,
+                DEFAULT_BADGE_CONTENT_PADDING,
+                true);
+
+            assert.deepEqual(result, [
+                {width: len4Width},
+                {width: len5Width},
+                {width: len3Width},
+                {width: len4Width},
+                {width: len5Width},
+                {width: len3Width},
+                {width: len4Width}
+            ]);
+        });
+
+        it("calculates badge styles for # columns = 4, alignmentPaddingWithinBadge = false", () => {
+            // columns => [1, 55555]
+            //            [222, 666]
+            //            [33, 7777]
+            //            [44]
+            const result = calculateBadgeAlignmentStyles(options, 4, false);
+
+            // value = 1
+            assert.equal(result[0].width, len1Width);
+            assert.equal(result[0].marginLeft, (len5Width - len1Width) / 2);
+            assert.equal(result[0].marginRight, (len5Width - len1Width) / 2);
+
+            // value = 222
+            assert.equal(result[1].width, len3Width);
+            assert.equal(result[1].marginLeft, 0);
+            assert.equal(result[1].marginRight, 0);
+
+            // value = 33
+            assert.equal(result[2].width, len2Width);
+            assert.equal(result[2].marginLeft, (len4Width - len2Width) / 2);
+            assert.equal(result[2].marginRight, (len4Width - len2Width) / 2);
+
+            // value = 44
+            assert.equal(result[3].width, len2Width);
+            assert.equal(result[3].marginLeft, 0);
+            assert.equal(result[3].marginRight, 0);
+
+            // value = 55555
+            assert.equal(result[4].width, len5Width);
+            assert.equal(result[4].marginLeft, 0);
+            assert.equal(result[4].marginRight, 0);
+
+            // value = 666
+            assert.equal(result[5].width, len3Width);
+            assert.equal(result[5].marginLeft, 0);
+            assert.equal(result[5].marginRight, 0);
+
+            // value = 7777
+            assert.equal(result[6].width, len4Width);
+            assert.equal(result[6].marginLeft, 0);
+            assert.equal(result[6].marginRight, 0);
+        });
+
+        it("calculates badge styles for # columns = 4, alignmentPaddingWithinBadge = true", () => {
+            // columns => [1, 55555]
+            //            [222, 666]
+            //            [33, 7777]
+            //            [44]
+            const result = calculateBadgeAlignmentStyles(options,
+                4,
+                false,
+                DEFAULT_BADGE_CHAR_WIDTH,
+                DEFAULT_BADGE_CONTENT_PADDING,
+                true);
+
+            assert.deepEqual(result, [
+                {width: len5Width},
+                {width: len3Width},
+                {width: len4Width},
+                {width: len2Width},
+                {width: len5Width},
+                {width: len3Width},
+                {width: len4Width}
+            ]);
+        });
+
+        it("calculates badge styles for # columns = 5, alignmentPaddingWithinBadge = false", () => {
+            // columns => [1, 666]
+            //            [222, 7777]
+            //            [33]
+            //            [44]
+            //            [55555]
+            const result = calculateBadgeAlignmentStyles(options, 5, false);
+
+            // value = 1
+            assert.equal(result[0].width, len1Width);
+            assert.equal(result[0].marginLeft, (len3Width - len1Width) / 2);
+            assert.equal(result[0].marginRight, (len3Width - len1Width) / 2);
+
+            // value = 222
+            assert.equal(result[1].width, len3Width);
+            assert.equal(result[1].marginLeft, (len4Width - len3Width) / 2);
+            assert.equal(result[1].marginRight, (len4Width - len3Width) / 2);
+
+            // value = 33
+            assert.equal(result[2].width, len2Width);
+            assert.equal(result[2].marginLeft, 0);
+            assert.equal(result[2].marginRight, 0);
+
+            // value = 44
+            assert.equal(result[3].width, len2Width);
+            assert.equal(result[3].marginLeft, 0);
+            assert.equal(result[3].marginRight, 0);
+
+            // value = 55555
+            assert.equal(result[4].width, len5Width);
+            assert.equal(result[4].marginLeft, 0);
+            assert.equal(result[4].marginRight, 0);
+
+            // value = 666
+            assert.equal(result[5].width, len3Width);
+            assert.equal(result[5].marginLeft, 0);
+            assert.equal(result[5].marginRight, 0);
+
+            // value = 7777
+            assert.equal(result[6].width, len4Width);
+            assert.equal(result[6].marginLeft, 0);
+            assert.equal(result[6].marginRight, 0);
+        });
+
+        it("calculates badge styles for # columns = 5, alignmentPaddingWithinBadge = true", () => {
+            // columns => [1, 666]
+            //            [222, 7777]
+            //            [33]
+            //            [44]
+            //            [55555]
+            const result = calculateBadgeAlignmentStyles(options,
+                5,
+                false,
+                DEFAULT_BADGE_CHAR_WIDTH,
+                DEFAULT_BADGE_CONTENT_PADDING,
+                true);
+
+            assert.deepEqual(result, [
+                {width: len3Width},
+                {width: len4Width},
+                {width: len2Width},
+                {width: len2Width},
+                {width: len5Width},
+                {width: len3Width},
+                {width: len4Width}
+            ]);
+        });
+
+        it("calculates badge styles for # columns = 6, alignmentPaddingWithinBadge = false", () => {
+            // columns => [1, 7777]
+            //            [222]
+            //            [33]
+            //            [44]
+            //            [55555]
+            //            [666]
+            const result = calculateBadgeAlignmentStyles(options, 6, false);
+
+            // value = 1
+            assert.equal(result[0].width, len1Width);
+            assert.equal(result[0].marginLeft, (len4Width - len1Width) / 2);
+            assert.equal(result[0].marginRight, (len4Width - len1Width) / 2);
+
+            // value = 222
+            assert.equal(result[1].width, len3Width);
+            assert.equal(result[1].marginLeft, 0);
+            assert.equal(result[1].marginRight, 0);
+
+            // value = 33
+            assert.equal(result[2].width, len2Width);
+            assert.equal(result[2].marginLeft, 0);
+            assert.equal(result[2].marginRight, 0);
+
+            // value = 44
+            assert.equal(result[3].width, len2Width);
+            assert.equal(result[3].marginLeft, 0);
+            assert.equal(result[3].marginRight, 0);
+
+            // value = 55555
+            assert.equal(result[4].width, len5Width);
+            assert.equal(result[4].marginLeft, 0);
+            assert.equal(result[4].marginRight, 0);
+
+            // value = 666
+            assert.equal(result[5].width, len3Width);
+            assert.equal(result[5].marginLeft, 0);
+            assert.equal(result[5].marginRight, 0);
+
+            // value = 7777
+            assert.equal(result[6].width, len4Width);
+            assert.equal(result[6].marginLeft, 0);
+            assert.equal(result[6].marginRight, 0);
+        });
+
+        it("calculates badge styles for # columns = 6, alignmentPaddingWithinBadge = true", () => {
+            // columns => [1, 7777]
+            //            [222]
+            //            [33]
+            //            [44]
+            //            [55555]
+            //            [666]
+            const result = calculateBadgeAlignmentStyles(options,
+                6,
+                false,
+                DEFAULT_BADGE_CHAR_WIDTH,
+                DEFAULT_BADGE_CONTENT_PADDING,
+                true);
+
+            assert.deepEqual(result, [
+                {width: len4Width},
+                {width: len3Width},
+                {width: len2Width},
+                {width: len2Width},
+                {width: len5Width},
+                {width: len3Width},
+                {width: len4Width}
+            ]);
+        });
+
+        it("calculates badge styles for # columns = 7, alignmentPaddingWithinBadge = false", () => {
+            // columns => [1]
+            //            [222]
+            //            [33]
+            //            [44]
+            //            [55555]
+            //            [666]
+            //            [7777]
+            const result = calculateBadgeAlignmentStyles(options, 7, false);
+
+            // value = 1
+            assert.equal(result[0].width, len1Width);
+            assert.equal(result[0].marginLeft, 0);
+            assert.equal(result[0].marginRight, 0);
+
+            // value = 222
+            assert.equal(result[1].width, len3Width);
+            assert.equal(result[1].marginLeft, 0);
+            assert.equal(result[1].marginRight, 0);
+
+            // value = 33
+            assert.equal(result[2].width, len2Width);
+            assert.equal(result[2].marginLeft, 0);
+            assert.equal(result[2].marginRight, 0);
+
+            // value = 44
+            assert.equal(result[3].width, len2Width);
+            assert.equal(result[3].marginLeft, 0);
+            assert.equal(result[3].marginRight, 0);
+
+            // value = 55555
+            assert.equal(result[4].width, len5Width);
+            assert.equal(result[4].marginLeft, 0);
+            assert.equal(result[4].marginRight, 0);
+
+            // value = 666
+            assert.equal(result[5].width, len3Width);
+            assert.equal(result[5].marginLeft, 0);
+            assert.equal(result[5].marginRight, 0);
+
+            // value = 7777
+            assert.equal(result[6].width, len4Width);
+            assert.equal(result[6].marginLeft, 0);
+            assert.equal(result[6].marginRight, 0);
+        });
+
+        it("calculates badge styles for # columns = 7, alignmentPaddingWithinBadge = true", () => {
+            // columns => [1]
+            //            [222]
+            //            [33]
+            //            [44]
+            //            [55555]
+            //            [666]
+            //            [7777]
+            const result = calculateBadgeAlignmentStyles(options,
+                7,
+                false,
+                DEFAULT_BADGE_CHAR_WIDTH,
+                DEFAULT_BADGE_CONTENT_PADDING,
+                true);
+
+            assert.deepEqual(result, [
+                {width: len1Width},
+                {width: len3Width},
+                {width: len2Width},
+                {width: len2Width},
+                {width: len5Width},
+                {width: len3Width},
+                {width: len4Width}
+            ]);
+        });
+
+        it("calculates badge styles for # columns > # options, alignmentPaddingWithinBadge = false", () => {
+            // columns => [1]
+            //            [222]
+            //            [33]
+            //            [44]
+            //            [55555]
+            //            [666]
+            //            [7777]
+            const result = calculateBadgeAlignmentStyles(options, 666, false);
+
+            assert.equal(result.length, 7);
+
+            // value = 1
+            assert.equal(result[0].width, len1Width);
+            assert.equal(result[0].marginLeft, 0);
+            assert.equal(result[0].marginRight, 0);
+
+            // value = 222
+            assert.equal(result[1].width, len3Width);
+            assert.equal(result[1].marginLeft, 0);
+            assert.equal(result[1].marginRight, 0);
+
+            // value = 33
+            assert.equal(result[2].width, len2Width);
+            assert.equal(result[2].marginLeft, 0);
+            assert.equal(result[2].marginRight, 0);
+
+            // value = 44
+            assert.equal(result[3].width, len2Width);
+            assert.equal(result[3].marginLeft, 0);
+            assert.equal(result[3].marginRight, 0);
+
+            // value = 55555
+            assert.equal(result[4].width, len5Width);
+            assert.equal(result[4].marginLeft, 0);
+            assert.equal(result[4].marginRight, 0);
+
+            // value = 666
+            assert.equal(result[5].width, len3Width);
+            assert.equal(result[5].marginLeft, 0);
+            assert.equal(result[5].marginRight, 0);
+
+            // value = 7777
+            assert.equal(result[6].width, len4Width);
+            assert.equal(result[6].marginLeft, 0);
+            assert.equal(result[6].marginRight, 0);
+        });
+
+        it("calculates badge styles for # columns > # options, alignmentPaddingWithinBadge = true", () => {
+            // columns => [1]
+            //            [222]
+            //            [33]
+            //            [44]
+            //            [55555]
+            //            [666]
+            //            [7777]
+            const result = calculateBadgeAlignmentStyles(options,
+                666,
+                false,
+                DEFAULT_BADGE_CHAR_WIDTH,
+                DEFAULT_BADGE_CONTENT_PADDING,
+                true);
+
+            assert.deepEqual(result, [
+                {width: len1Width},
+                {width: len3Width},
+                {width: len2Width},
+                {width: len2Width},
+                {width: len5Width},
+                {width: len3Width},
+                {width: len4Width}
+            ]);
+        });
+
+        it("calculates a uniform badge width regardless of the # columns or alignmentPaddingWithinBadge value", () => {
+            const expected = [
+                {width: len5Width},
+                {width: len5Width},
+                {width: len5Width},
+                {width: len5Width},
+                {width: len5Width},
+                {width: len5Width},
+                {width: len5Width}
+            ];
+
+            assert.deepEqual(calculateBadgeAlignmentStyles(
+                options, 1, true),
+                expected);
+            assert.deepEqual(calculateBadgeAlignmentStyles(
+                options, 2, true),
+                expected);
+            assert.deepEqual(calculateBadgeAlignmentStyles(
+                options, 3, true, DEFAULT_BADGE_CHAR_WIDTH, DEFAULT_BADGE_CONTENT_PADDING, true),
+                expected);
+            assert.deepEqual(calculateBadgeAlignmentStyles(
+                options, 4, true, DEFAULT_BADGE_CHAR_WIDTH, DEFAULT_BADGE_CONTENT_PADDING, false),
+                expected);
+            assert.deepEqual(calculateBadgeAlignmentStyles(
+                options, 5, true, DEFAULT_BADGE_CHAR_WIDTH, DEFAULT_BADGE_CONTENT_PADDING, true),
+                expected);
+            assert.deepEqual(calculateBadgeAlignmentStyles(
+                options, 6, true, DEFAULT_BADGE_CHAR_WIDTH, DEFAULT_BADGE_CONTENT_PADDING, false),
+                expected);
+            assert.deepEqual(calculateBadgeAlignmentStyles(
+                options, 7, true),
+                expected);
+            assert.deepEqual(calculateBadgeAlignmentStyles(
+                options, 666, true),
+                expected);
+            assert.deepEqual(calculateBadgeAlignmentStyles(
+                options, 666, true),
+                expected);
+        });
+
+    });
+});

--- a/src/component/filter/BadgeSelector.tsx
+++ b/src/component/filter/BadgeSelector.tsx
@@ -1,5 +1,6 @@
 import autobind from "autobind-decorator";
 import {CheckBoxType, Checklist, getSelectedValuesMap, Option} from "cbioportal-frontend-commons";
+import _ from "lodash";
 import {action, computed} from "mobx";
 import {observer} from "mobx-react";
 import * as React from 'react';
@@ -23,6 +24,9 @@ export type BadgeSelectorProps = {
     isDisabled?: boolean;
     unselectOthersWhenAllSelected?: boolean;
     numberOfColumnsPerRow?: number;
+    alignColumns?: boolean;
+    uniformBadgeWidth?: boolean;
+    alignmentPaddingWithinBadge?: boolean;
     onSelect?: (selectedOptionIds: string[], allValuesSelected?: boolean) => void;
     selectedValues?: {value: string}[];
     getOptionLabel?: (option: Option,
@@ -30,29 +34,123 @@ export type BadgeSelectorProps = {
                       checkBoxType?: CheckBoxType) => JSX.Element;
     getBadgeLabel?: (option: BadgeSelectorOption,
                      selectedValues: {[optionValue: string]: any},
-                     badgeClassName?: string) => JSX.Element;
+                     badgeClassName?: string,
+                     badgeAlignmentStyle?: CSSProperties) => JSX.Element;
     filter?: DataFilter<string>;
     options?: BadgeSelectorOption[];
     badgeClassName?: string;
+    badgeContentPadding?: number;
+    badgeCharWidth?: number;
 };
 
-export function getBadgeStyleOverride(option: BadgeSelectorOption, selectedValues: {[optionValue: string]: any})
+export const DEFAULT_BADGE_CHAR_WIDTH = 10;
+export const DEFAULT_BADGE_CONTENT_PADDING = 7;
+
+export function getBadgeStyleOverride(option: BadgeSelectorOption,
+                                      selectedValues: {[optionValue: string]: any},
+                                      badgeAlignmentStyle?: CSSProperties)
 {
-    let override = option.badgeStyleOverride;
-    const defaultStyle = {...DEFAULT_BADGE_STYLE, ...override};
+    let override: CSSProperties = {
+        ...badgeAlignmentStyle,
+        ...option.badgeStyleOverride
+    };
+
+    const defaultStyle = {
+        ...DEFAULT_BADGE_STYLE,
+        ...override
+    };
+
     const isSelected = option.value in selectedValues;
 
     if (!isSelected)
     {
         // by default swap background color and text color for unselected options
-        override = option.badgeStyleSelectedOverride || {
-            color: defaultStyle.backgroundColor,
-            backgroundColor: defaultStyle.color,
-            borderColor: defaultStyle.backgroundColor
-        }
+        override = option.badgeStyleSelectedOverride ?
+            {
+                ...badgeAlignmentStyle,
+                ...option.badgeStyleSelectedOverride
+            }: {
+                ...defaultStyle,
+                color: defaultStyle.backgroundColor,
+                backgroundColor: defaultStyle.color,
+                borderColor: defaultStyle.backgroundColor
+            }
     }
 
     return override;
+}
+
+export function calculateBadgeAlignmentStyle(maxLengthInCol: number,
+                                             optionLength: number,
+                                             badgeCharWidth: number = DEFAULT_BADGE_CHAR_WIDTH,
+                                             badgeContentPadding: number = DEFAULT_BADGE_CONTENT_PADDING,
+                                             padWithinBadge: boolean = false): CSSProperties
+{
+    // this is an approximation with the assumption that each character has more or less equal width
+    const totalWidth = (maxLengthInCol * badgeCharWidth) + (badgeContentPadding * 2);
+
+    if (padWithinBadge) {
+        // no additional left or right margin, since all the padding is applied within the badge width
+        return {
+            width: totalWidth
+        };
+    }
+    else {
+        // need additional left and right margins to adjust the alignment
+        const width = (optionLength * badgeCharWidth) + (badgeContentPadding * 2);
+        const margin = (totalWidth - width) / 2;
+        return {
+            width,
+            marginLeft: margin,
+            marginRight: margin
+        }
+    }
+}
+
+export function getOptionContentLengths(options: BadgeSelectorOption[]): number[]
+{
+    // string length of each badge content of an option
+    return options
+        .map((option: BadgeSelectorOption) => option.badgeContent)
+        .filter(content => content !== undefined)
+        .map(content => content!.toString().length);
+}
+
+export function calculateBadgeAlignmentStyles(options: BadgeSelectorOption[],
+                                              numberOfColumnsPerRow: number = 1,
+                                              uniformBadgeWidth: boolean = false,
+                                              badgeCharWidth: number = DEFAULT_BADGE_CHAR_WIDTH,
+                                              badgeContentPadding: number = DEFAULT_BADGE_CONTENT_PADDING,
+                                              alignmentPaddingWithinBadge: boolean = false): CSSProperties[]
+{
+    // regardless of number of columns or alignmentPaddingWithinBadge value
+    // set the width of all badges to the width of badge with the longest content
+    if (uniformBadgeWidth) {
+        const iterationCount = options.length;
+        const maxLength = Math.max(...getOptionContentLengths(options));
+        const badgeWidth = calculateBadgeAlignmentStyle(maxLength, maxLength, badgeCharWidth, badgeContentPadding, true);
+
+        return _.times(iterationCount, () => badgeWidth);
+    }
+    else if (numberOfColumnsPerRow > 0) {
+        const groupedByCol = _.groupBy(options, option => options.indexOf(option) % numberOfColumnsPerRow);
+
+        return options.map( (option: BadgeSelectorOption, index: number) => {
+            // define a max badge length for each column
+            const maxLengthInCol = Math.max(...getOptionContentLengths(groupedByCol[index % numberOfColumnsPerRow]));
+            const length = option.badgeContent === undefined ? 0: option.badgeContent.toString().length;
+
+            // align all badges with respect to the max badge length for the corresponding column
+            return calculateBadgeAlignmentStyle(maxLengthInCol,
+                length,
+                badgeCharWidth,
+                badgeContentPadding,
+                alignmentPaddingWithinBadge);
+        });
+    }
+    else {
+        return [];
+    }
 }
 
 @observer
@@ -75,24 +173,42 @@ export class BadgeSelector extends React.Component<BadgeSelectorProps, {}>
 
     public getBadgeLabel(option: BadgeSelectorOption,
                          selectedValues: {[optionValue: string]: any},
-                         badgeClassName?: string): JSX.Element
+                         badgeClassName?: string,
+                         badgeAlignmentStyle?: CSSProperties): JSX.Element
     {
         return this.props.getBadgeLabel ?
-            this.props.getBadgeLabel(option, selectedValues, badgeClassName): (
+            this.props.getBadgeLabel(option, selectedValues, badgeClassName, badgeAlignmentStyle): (
                 <BadgeLabel
                     label={option.label || option.value}
                     badgeContent={option.badgeContent}
-                    badgeStyleOverride={getBadgeStyleOverride(option, selectedValues)}
+                    badgeStyleOverride={getBadgeStyleOverride(option, selectedValues, badgeAlignmentStyle)}
                     badgeClassName={this.props.badgeClassName}
                 />
             );
     }
 
     @computed
+    public get badgeAlignmentStyles(): CSSProperties[] | undefined
+    {
+        return this.props.alignColumns && this.props.options ?
+            calculateBadgeAlignmentStyles(this.props.options,
+                this.props.numberOfColumnsPerRow,
+                this.props.uniformBadgeWidth,
+                this.props.badgeCharWidth,
+                this.props.badgeContentPadding,
+                this.props.alignmentPaddingWithinBadge):
+            undefined;
+    }
+
+    @computed
     public get options(): Option[] {
         return (this.props.options || [])
-            .map(option => ({
-                label: this.getBadgeLabel(option, this.selectedValuesMap, this.props.badgeClassName),
+            .map((option, index) => ({
+                label: this.getBadgeLabel(option,
+                    this.selectedValuesMap,
+                    this.props.badgeClassName,
+                    this.badgeAlignmentStyles && this.props.numberOfColumnsPerRow ?
+                        this.badgeAlignmentStyles[index]: undefined),
                 value: option.value
             }));
     }

--- a/src/component/filter/ProteinImpactTypeBadgeSelector.tsx
+++ b/src/component/filter/ProteinImpactTypeBadgeSelector.tsx
@@ -2,6 +2,7 @@ import {Option, ProteinImpactType} from "cbioportal-frontend-commons";
 import {computed} from "mobx";
 import {observer} from "mobx-react";
 import * as React from 'react';
+import {CSSProperties} from "react";
 
 import {IProteinImpactTypeColors} from "../../model/ProteinImpact";
 import {DEFAULT_PROTEIN_IMPACT_TYPE_COLORS} from "../../util/MutationUtils";
@@ -29,13 +30,14 @@ export function getProteinImpactTypeOptionLabel(option: Option): JSX.Element
 
 export function getProteinImpactTypeBadgeLabel(option: BadgeSelectorOption,
                                                selectedValues: {[optionValue: string]: any},
-                                               badgeClassName?: string): JSX.Element
+                                               badgeClassName?: string,
+                                               badgeAlignmentStyle?: CSSProperties): JSX.Element
 {
     return (
         <BadgeLabel
             label={option.label || option.value}
             badgeContent={option.badgeContent}
-            badgeStyleOverride={getBadgeStyleOverride(option, selectedValues)}
+            badgeStyleOverride={getBadgeStyleOverride(option, selectedValues, badgeAlignmentStyle)}
             badgeClassName={badgeClassName}
             badgeFirst={true}
         />
@@ -47,6 +49,7 @@ export class ProteinImpactTypeBadgeSelector extends React.Component<ProteinImpac
 {
     public static defaultProps: Partial<ProteinImpactTypeBadgeSelectorProps> = {
         colors: DEFAULT_PROTEIN_IMPACT_TYPE_COLORS,
+        alignColumns: true,
         unselectOthersWhenAllSelected: true,
         numberOfColumnsPerRow: 2
     };


### PR DESCRIPTION
Examples (for default settings):

![mutation_type_selector_aligned_01](https://user-images.githubusercontent.com/3604198/70186980-27c2e180-16bb-11ea-838e-39ad1169ef62.png)

![mutation_type_selector_aligned_02](https://user-images.githubusercontent.com/3604198/70186985-298ca500-16bb-11ea-9b8b-3b463c4bcc34.png)

![mutation_type_selector_aligned_03](https://user-images.githubusercontent.com/3604198/70186993-301b1c80-16bb-11ea-9696-88a803966bc4.png)

